### PR TITLE
Update SwiftyJSON pod

### DIFF
--- a/JSONAPIModel.podspec
+++ b/JSONAPIModel.podspec
@@ -13,5 +13,5 @@ Pod::Spec.new do |spec|
     tag: "v#{spec.version}"
   }
   spec.source_files = 'JSONAPIModel/*.swift', 'JSONAPIModel/**/*.swift'
-  spec.dependency 'SwiftyJSON', '~> 4.0'
+  spec.dependency 'SwiftyJSON', '~> 5.0'
 end


### PR DESCRIPTION
This should be a non-breaking change: https://github.com/SwiftyJSON/SwiftyJSON/releases/tag/5.0.0

I have tested by pointing the kiosk podfile to a local version of JSONAPIModel with this change.